### PR TITLE
Fix out-of-range jumps in DrawPixel

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -208,9 +208,15 @@ DrawPixel PROC
     push es
 
     cmp bx, 159                    ; Fix: Limit viewport 160x100
-    ja @exit_pixel
+    jbe @CheckYBounds
+    jmp NEAR PTR @exit_pixel
+
+@CheckYBounds:
     cmp cx, 99                     ; Fix: Limit viewport 160x100
-    ja @exit_pixel
+    jbe @PixelWithinBounds
+    jmp NEAR PTR @exit_pixel
+
+@PixelWithinBounds:
 
     mov dh, dl                     ; Fix: Conservar el color completo en DH
 


### PR DESCRIPTION
## Summary
- ensure DrawPixel bounds checks use near jumps to avoid TASM range errors
- add intermediate labels so out-of-bounds pixels exit safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df3f0e2000832c8eb8c69f9bdcd948