### PR TITLE
Use static planar buffers stored in data segment

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -9,14 +9,13 @@ SCREEN_WIDTH      EQU 640         ; Ancho de pantalla en píxeles
 SCREEN_HEIGHT     EQU 350         ; Alto de pantalla en píxeles
 BYTES_PER_SCAN    EQU 20          ; Fix: Ajuste a viewport 160x100 (160/8)
 PLANE_SIZE        EQU 2000        ; Fix: Tamaño del plano reducido (20 bytes * 100 scans)
-PLANE_PARAGRAPHS  EQU 128         ; Fix: 128 párrafos (8 KB) para reserva segura
 
 .DATA                             ; Segmento de datos
-Plane0Segment    dw 0             ; Segmento del plano 0 (bit de peso 1)
-Plane1Segment    dw 0             ; Segmento del plano 1 (bit de peso 2)
-Plane2Segment    dw 0             ; Segmento del plano 2 (bit de peso 4)
-Plane3Segment    dw 0             ; Segmento del plano 3 (bit de peso 8)
-psp_seg          dw 0             ; Fix: Para PSP segment
+; Fix: Buffer fijo .DATA para Fase 2 sin bugs DOSBox
+plane0           db 2000 dup(0)    ; Buffer fijo planar 2000 bytes/plano
+plane1           db 2000 dup(0)
+plane2           db 2000 dup(0)
+plane3           db 2000 dup(0)
 viewport_x_offset dw 30           ; Fix: Desfase horizontal (centrado 160 px en 640)
 viewport_y_offset dw 10000        ; Fix: Desfase vertical (125 scans * 80 bytes)
 msg_err          db 'ERROR: Alloc fallo. Codigo: $'
@@ -33,46 +32,8 @@ crlf             db 13,10,'$'
 ; cargador asigna al .EXE al iniciarse.
 ; -------------------------------------------------------------------------
 ShrinkProgramMemory PROC
-    push ax
-    push bx
-    push cx
-    push dx
-    push es
-
-    mov ax, psp_seg
-    or ax, ax
-    jnz @have_psp
-
-    mov ah, 51h                     ; Fix: Obtener segmento del PSP actual
-    int 21h
-    mov psp_seg, bx
-
-@have_psp:
-    mov es, psp_seg                 ; PSP segment para INT 21h/4Ah
-    mov ax, es:[2]                  ; AX = párrafos originales
-    shr ax, 1                       ; Fix: Estimar tamaño de código propio
-
-    mov ah, 4Ah                     ; Función DOS para encoger bloque
-    mov bx, 100                     ; Fix: Shrink programa a 100 paragraphs para liberar mem para alloc
-    int 21h
-    jc @shrink_fail
-
-    xor ax, ax                      ; Fix: AX=0 indica shrink exitoso
-    jmp @exit
-
-@shrink_fail:
-    ; Fix: Quitar mensaje shrink para evitar basura en salida
-    ; mov dx, offset msg_shrink_fail
-    ; mov ah, 09h
-    ; int 21h
-    mov ax, 1                       ; Fix: AX=1 indica shrink no disponible
-
-@exit:
-    pop es
-    pop dx
-    pop cx
-    pop bx
-    pop ax
+    ; Fix: Buffer fijo .DATA para Fase 2 sin bugs DOSBox
+    xor ax, ax
     ret
 ShrinkProgramMemory ENDP
 
@@ -83,55 +44,8 @@ ShrinkProgramMemory ENDP
 ; éxito; en caso contrario, AX contiene el código de error devuelto por DOS.
 ; -------------------------------------------------------------------------
 InitOffScreenBuffer PROC
-    push bx
-    push cx
-    push dx
-    push es
-
-    ; Asegurarse de que los segmentos están en cero antes de reservar.
-    mov Plane0Segment, 0
-    mov Plane1Segment, 0
-    mov Plane2Segment, 0
-    mov Plane3Segment, 0
-
-    mov bx, PLANE_PARAGRAPHS      ; Fix: Reserva 8 KB por plano reducido
-
-    mov ah, 48h                    ; Reservar memoria para el plano 0
-    int 21h
-    jc @AllocationFailed
-    mov Plane0Segment, ax
-
-    mov ah, 48h                    ; Reservar memoria para el plano 1
-    mov bx, PLANE_PARAGRAPHS      ; Fix: Reaplicar tamaño reducido
-    int 21h
-    jc @AllocationFailed
-    mov Plane1Segment, ax
-
-    mov ah, 48h                    ; Reservar memoria para el plano 2
-    mov bx, PLANE_PARAGRAPHS      ; Fix: Reaplicar tamaño reducido
-    int 21h
-    jc @AllocationFailed
-    mov Plane2Segment, ax
-
-    mov ah, 48h                    ; Reservar memoria para el plano 3
-    mov bx, PLANE_PARAGRAPHS      ; Fix: Reaplicar tamaño reducido
-    int 21h
-    jc @AllocationFailed
-    mov Plane3Segment, ax
-
-    xor ax, ax                     ; AX=0 indica éxito
-    jmp @InitExit
-
-@AllocationFailed:
-    push ax                        ; Guardar código de error
-    call ReleaseOffScreenBuffer    ; Liberar cualquier bloque ya reservado
-    pop ax                         ; Recuperar el código de error original
-
-@InitExit:
-    pop es
-    pop dx
-    pop cx
-    pop bx
+    ; Fix: Buffer fijo .DATA para Fase 2 sin bugs DOSBox
+    xor ax, ax
     ret
 InitOffScreenBuffer ENDP
 
@@ -141,47 +55,7 @@ InitOffScreenBuffer ENDP
 ; off-screen (INT 21h, función 49h).
 ; -------------------------------------------------------------------------
 ReleaseOffScreenBuffer PROC
-    push ax
-    push es
-
-    mov ax, Plane0Segment
-    or ax, ax
-    jz @SkipFree0
-    mov es, ax
-    mov ah, 49h
-    int 21h
-    mov Plane0Segment, 0
-@SkipFree0:
-
-    mov ax, Plane1Segment
-    or ax, ax
-    jz @SkipFree1
-    mov es, ax
-    mov ah, 49h
-    int 21h
-    mov Plane1Segment, 0
-@SkipFree1:
-
-    mov ax, Plane2Segment
-    or ax, ax
-    jz @SkipFree2
-    mov es, ax
-    mov ah, 49h
-    int 21h
-    mov Plane2Segment, 0
-@SkipFree2:
-
-    mov ax, Plane3Segment
-    or ax, ax
-    jz @SkipFree3
-    mov es, ax
-    mov ah, 49h
-    int 21h
-    mov Plane3Segment, 0
-@SkipFree3:
-
-    pop es
-    pop ax
+    ; Fix: Buffer fijo .DATA para Fase 2 sin bugs DOSBox
     ret
 ReleaseOffScreenBuffer ENDP
 
@@ -195,45 +69,25 @@ ClearOffScreenBuffer PROC
     push di
     push es
 
-    mov ax, Plane0Segment          ; Borrar plano 0
-    or ax, ax
-    jz @SkipPlane0
-    mov es, ax
-    xor ax, ax                     ; Fix: AL=0 para stosb
-    xor di, di
-    mov cx, PLANE_SIZE            ; Fix: Conteo ajustado al viewport reducido
-    rep stosb
-@SkipPlane0:
+    mov ax, @data
+    mov es, ax                     ; Clear fijo en ES=@data
 
-    mov ax, Plane1Segment          ; Borrar plano 1
-    or ax, ax
-    jz @SkipPlane1
-    mov es, ax
-    xor ax, ax                     ; Fix: AL=0 para stosb
-    xor di, di
-    mov cx, PLANE_SIZE            ; Fix: Conteo ajustado al viewport reducido
+    mov di, OFFSET plane0
+    mov al, 0
+    mov cx, 2000
     rep stosb
-@SkipPlane1:
 
-    mov ax, Plane2Segment          ; Borrar plano 2
-    or ax, ax
-    jz @SkipPlane2
-    mov es, ax
-    xor ax, ax                     ; Fix: AL=0 para stosb
-    xor di, di
-    mov cx, PLANE_SIZE            ; Fix: Conteo ajustado al viewport reducido
+    mov di, OFFSET plane1
+    mov cx, 2000
     rep stosb
-@SkipPlane2:
 
-    mov ax, Plane3Segment          ; Borrar plano 3
-    or ax, ax
-    jz @SkipPlane3
-    mov es, ax
-    xor ax, ax                     ; Fix: AL=0 para stosb
-    xor di, di
-    mov cx, PLANE_SIZE            ; Fix: Conteo ajustado al viewport reducido
+    mov di, OFFSET plane2
+    mov cx, 2000
     rep stosb
-@SkipPlane3:
+
+    mov di, OFFSET plane3
+    mov cx, 2000
+    rep stosb
 
     pop es                         ; Restaurar registros
     pop di
@@ -294,59 +148,6 @@ SetPaletteWhite PROC
     ret
 SetPaletteWhite ENDP
 
-; Test: Direct draw cruz blanca/roja top-left sin buffer
-DirectDrawTest PROC
-    push ax
-    push bx
-    push cx
-    push dx
-    push di
-    push es
-
-    mov ax, 0A000h
-    mov es, ax
-
-    mov dx, 03C4h
-    mov al, 2
-    out dx, al
-    inc dx
-    mov al, 4
-    out dx, al
-    dec dx
-
-    xor di, di
-    mov al, 4
-    mov cx, 160
-    rep stosb
-
-    xor di, di
-    mov cx, 100
-@vert:
-    mov BYTE PTR es:[di], 4
-    add di, 80
-    loop @vert
-
-    mov al, 2
-    out dx, al
-    inc dx
-    mov al, 0Fh
-    out dx, al
-    dec dx
-
-    xor di, di
-    mov al, 15
-    mov cx, 160
-    rep stosb
-
-    pop es
-    pop di
-    pop dx
-    pop cx
-    pop bx
-    pop ax
-    ret
-DirectDrawTest ENDP
-
 ; Fix: Limpia full A000h para eliminar garbage de modo anterior
 ClearScreen PROC
     push ax
@@ -396,7 +197,6 @@ DrawPixel PROC
     push dx
     push si
     push di
-    push es
 
     cmp bx, 159                    ; Fix: Limit viewport 160x100
     jbe @CheckYBounds
@@ -432,68 +232,54 @@ DrawPixel PROC
 
     mov si, di                     ; Fix: Guardar offset para reutilizar en cada plano
 
-    mov ax, Plane0Segment          ; Plano 0 (bit 0)
-    or ax, ax
-    jz @NextPlane0
+    mov ax, @data
     mov es, ax
+
     mov di, si
     test dh, 1
     jz @ClearPlane0
     mov al, bl
-    or BYTE PTR es:[di], al        ; Fix: Especificar tamaño byte al establecer
+    or BYTE PTR es:[OFFSET plane0 + di], al    ; Fix: Buffer fijo .DATA para Fase 2 sin bugs DOSBox
     jmp @NextPlane0
 @ClearPlane0:
     mov al, bh
-    and BYTE PTR es:[di], al       ; Fix: Especificar tamaño byte al limpiar
+    and BYTE PTR es:[OFFSET plane0 + di], al
 @NextPlane0:
 
-    mov ax, Plane1Segment          ; Plano 1 (bit 1)
-    or ax, ax
-    jz @NextPlane1
-    mov es, ax
     mov di, si
     test dh, 2
     jz @ClearPlane1
     mov al, bl
-    or BYTE PTR es:[di], al        ; Fix: Especificar tamaño byte al establecer
+    or BYTE PTR es:[OFFSET plane1 + di], al
     jmp @NextPlane1
 @ClearPlane1:
     mov al, bh
-    and BYTE PTR es:[di], al       ; Fix: Especificar tamaño byte al limpiar
+    and BYTE PTR es:[OFFSET plane1 + di], al
 @NextPlane1:
 
-    mov ax, Plane2Segment          ; Plano 2 (bit 2)
-    or ax, ax
-    jz @NextPlane2
-    mov es, ax
     mov di, si
     test dh, 4
     jz @ClearPlane2
     mov al, bl
-    or BYTE PTR es:[di], al        ; Fix: Especificar tamaño byte al establecer
+    or BYTE PTR es:[OFFSET plane2 + di], al
     jmp @NextPlane2
 @ClearPlane2:
     mov al, bh
-    and BYTE PTR es:[di], al       ; Fix: Especificar tamaño byte al limpiar
+    and BYTE PTR es:[OFFSET plane2 + di], al
 @NextPlane2:
 
-    mov ax, Plane3Segment          ; Plano 3 (bit 3)
-    or ax, ax
-    jz @NextPlane3
-    mov es, ax
     mov di, si
     test dh, 8
     jz @ClearPlane3
     mov al, bl
-    or BYTE PTR es:[di], al        ; Fix: Especificar tamaño byte al establecer
+    or BYTE PTR es:[OFFSET plane3 + di], al
     jmp @NextPlane3
 @ClearPlane3:
     mov al, bh
-    and BYTE PTR es:[di], al       ; Fix: Especificar tamaño byte al limpiar
+    and BYTE PTR es:[OFFSET plane3 + di], al
 @NextPlane3:
 
 @exit_pixel:
-    pop es                         ; Restaurar registros
     pop di
     pop si
     pop dx
@@ -518,107 +304,62 @@ BlitBufferToScreen PROC
     push ds
     push es
 
-    mov ax, 0A000h                 ; Fix: Cargar segmento de video en ES
-    mov es, ax
-    mov dx, 03C4h                  ; Fix: Puerto base del sequencer
+    mov ax, @data
+    mov ds, ax
+    mov ax, 0A000h
+    mov es, ax                     ; Blit fijo DS=@data to ES top-left
+    mov dx, 03C4h
 
-    mov ax, Plane0Segment          ; Plano 0 ------------------------------------------------
-    or ax, ax
-    jz @SkipCopy0
-    mov bx, ax                     ; Fix: Preservar segmento del plano
     mov al, 02h
     out dx, al
     inc dx
-    mov al, 1                      ; Fix: Máscara decimal para plano 0
+    mov al, 1
     out dx, al
     dec dx
-    push ds                        ; Fix: Guardar DS antes de cambiarlo al plano
-    xor di, di                     ; Fix: Top-left sin offset para el blit
-    ; Test: Blit viewport top-left para DOSBox
-    ; mov ax, viewport_y_offset      ; Fix: Obtener desplazamiento vertical base
-    ; mov di, ax
-    ; add di, viewport_x_offset      ; Fix: Desplazar viewport centrado
-    mov ds, bx                     ; Fix: Usar segmento preservado del plano
-    xor si, si
-    mov cx, PLANE_SIZE            ; Fix: Conteo reducido del plano
+    mov si, OFFSET plane0
+    xor di, di
+    mov cx, 2000
     rep movsb
-    pop ds
-@SkipCopy0:
 
-    mov ax, Plane1Segment          ; Plano 1 ------------------------------------------------
-    or ax, ax
-    jz @SkipCopy1
-    mov bx, ax                     ; Fix: Preservar segmento del plano
     mov al, 02h
     out dx, al
     inc dx
-    mov al, 2                      ; Fix: Máscara decimal para plano 1
+    mov al, 2
     out dx, al
     dec dx
-    push ds                        ; Fix: Guardar DS antes de cambiarlo al plano
-    xor di, di                     ; Fix: Top-left sin offset para el blit
-    ; Test: Blit viewport top-left para DOSBox
-    ; mov ax, viewport_y_offset      ; Fix: Obtener desplazamiento vertical base
-    ; mov di, ax
-    ; add di, viewport_x_offset      ; Fix: Desplazar viewport centrado
-    mov ds, bx                     ; Fix: Usar segmento preservado del plano
-    xor si, si
-    mov cx, PLANE_SIZE            ; Fix: Conteo reducido del plano
+    mov si, OFFSET plane1
+    xor di, di
+    mov cx, 2000
     rep movsb
-    pop ds
-@SkipCopy1:
 
-    mov ax, Plane2Segment          ; Plano 2 ------------------------------------------------
-    or ax, ax
-    jz @SkipCopy2
-    mov bx, ax                     ; Fix: Preservar segmento del plano
     mov al, 02h
     out dx, al
     inc dx
-    mov al, 4                      ; Fix: Máscara decimal para plano 2
+    mov al, 4
     out dx, al
     dec dx
-    push ds                        ; Fix: Guardar DS antes de cambiarlo al plano
-    xor di, di                     ; Fix: Top-left sin offset para el blit
-    ; Test: Blit viewport top-left para DOSBox
-    ; mov ax, viewport_y_offset      ; Fix: Obtener desplazamiento vertical base
-    ; mov di, ax
-    ; add di, viewport_x_offset      ; Fix: Desplazar viewport centrado
-    mov ds, bx                     ; Fix: Usar segmento preservado del plano
-    xor si, si
-    mov cx, PLANE_SIZE            ; Fix: Conteo reducido del plano
+    mov si, OFFSET plane2
+    xor di, di
+    mov cx, 2000
     rep movsb
-    pop ds
-@SkipCopy2:
 
-    mov ax, Plane3Segment          ; Plano 3 ------------------------------------------------
-    or ax, ax
-    jz @SkipCopy3
-    mov bx, ax                     ; Fix: Preservar segmento del plano
     mov al, 02h
     out dx, al
     inc dx
-    mov al, 8                      ; Fix: Máscara decimal para plano 3
+    mov al, 8
     out dx, al
     dec dx
-    push ds                        ; Fix: Guardar DS antes de cambiarlo al plano
-    xor di, di                     ; Fix: Top-left sin offset para el blit
-    ; Test: Blit viewport top-left para DOSBox
-    ; mov ax, viewport_y_offset      ; Fix: Obtener desplazamiento vertical base
-    ; mov di, ax
-    ; add di, viewport_x_offset      ; Fix: Desplazar viewport centrado
-    mov ds, bx                     ; Fix: Usar segmento preservado del plano
-    xor si, si
-    mov cx, PLANE_SIZE            ; Fix: Conteo reducido del plano
+    mov si, OFFSET plane3
+    xor di, di
+    mov cx, 2000
     rep movsb
-    pop ds
-@SkipCopy3:
 
-    mov al, 02h                    ; Fix: Restaurar índice del registro de máscara
+    mov al, 02h
     out dx, al
     inc dx
-    mov al, 0Fh                    ; Fix: Habilitar los cuatro planos
+    mov al, 0Fh
     out dx, al
+    dec dx
 
     pop es                         ; Restaurar registros
     pop ds
@@ -676,43 +417,12 @@ main PROC
     mov ax, @data                  ; Inicializar el segmento de datos
     mov ds, ax
 
-    call ShrinkProgramMemory       ; Fix: Liberar memoria prestada antes de reservar planos
-
-    call InitOffScreenBuffer       ; Reservar memoria para el buffer off-screen
-    cmp ax, 0
-    je @ok_print
-
-    mov si, ax                     ; Fix: Preservar código de error
-    mov dx, offset msg_err         ; Fix: Mensaje de error
-    mov ah, 09h
-    int 21h
-    mov ax, si
-    push ax                        ; Fix: Guardar error para depuración
-    call PrintHexAX
-    mov dx, offset msg_free        ; Fix: Mostrar bloque libre más grande
-    mov ah, 09h
-    int 21h
-    pop ax                         ; Fix: Limpiar pila tras imprimir error
-    mov ax, bx
-    call PrintHexAX
-    mov dx, offset crlf
-    mov ah, 09h
-    int 21h
-    mov ah, 4Ch                    ; Fix: Salir con código de error genérico 8
-    mov al, 8
-    int 21h
-
-@ok_print:
-@BuffersReady:
-
     mov ax, 0010h                  ; Cambiar a modo gráfico EGA 640x350x16
     int 10h
 
     call ClearScreen              ; Fix: Limpiar VRAM y evitar basura previa
     call SetPaletteRed             ; Fix: Color 4 = rojo brillante (R=63)
     call SetPaletteWhite           ; Test: Paleta blanco puro para referencia en color 15
-
-    ; call DirectDrawTest            ; Test directo en VRAM sin buffer
 
     call ClearOffScreenBuffer      ; Preparar buffer off-screen
 
@@ -741,8 +451,6 @@ VertLoop:
 
     mov ax, 0003h                  ; Volver a modo texto 80x25
     int 10h
-
-    call ReleaseOffScreenBuffer    ; Liberar memoria reservada
 
     mov ax, 4C00h                  ; Terminar programa
     int 21h


### PR DESCRIPTION
## Summary
- replace the dynamic planar allocation with four fixed 2000-byte planes defined in the data segment
- update the clear, draw, and blit routines to operate on the static buffers and eliminate DOS allocation/shrink helpers
- simplify `main` to rely on the fixed buffers and remove the direct VRAM test procedure

## Testing
- not run (assembly program)


------
https://chatgpt.com/codex/tasks/task_e_68df5034b4bc832cb4376bf8ffc88532