### PR TITLE
Fix PSP segment load before shrinking memory

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -54,7 +54,8 @@ ShrinkProgramMemory PROC
     mov psp_seg, bx
 
 @have_psp:
-    mov es, psp_seg
+    mov ax, psp_seg
+    mov es, ax
     mov ax, es:[2]
     shr ax, 1
 


### PR DESCRIPTION
## Summary
- load the stored PSP segment into AX before assigning ES in ShrinkProgramMemory so INT 21h/4Ah targets the correct block

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df6351834c832c9cecb2e59825985b