### PR TITLE
Fix long jump to exit input handler

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -547,7 +547,10 @@ HandleInput PROC
     xor ah, ah
     int 16h
     cmp al, 27
-    je @exit_input
+    jne @continue_input
+    jmp NEAR PTR @exit_input        ; Fix: Salto cercano para evitar overflow de salto corto
+
+@continue_input:
 
     cmp ah, 48h
     jne @check_down


### PR DESCRIPTION
## Summary
- replace the out-of-range short jump in the input handler with a near jump via an intermediate label to reach the exit path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df696c94ec832c853a682b96c3546d