### PR TITLE
Fix jump to exit input in HandleInput

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -547,8 +547,10 @@ HandleInput PROC
     xor ah, ah
     int 16h
     cmp al, 27
-    je @exit_input
+    jne @check_special_keys
+    jmp @exit_input
 
+@check_special_keys:
     cmp ah, 48h
     je @move_up
     cmp ah, 50h


### PR DESCRIPTION
## Summary
- adjust the ESC key handling logic in `HandleInput` to use a near jump path
- prevent the assembler from emitting a relative jump that exceeds the short jump range

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df6bea89cc832cb252f251e94266ac