### PR TITLE
Fix out-of-range jumps in input handler

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -652,10 +652,13 @@ HandleInput PROC
 
 @clamp_y_high:
     cmp ax, VIEWPORT_MAX_Y
-    jbe @frame_loop
+    ja @limit_y_high
+    jmp NEAR PTR @frame_loop
+
+@limit_y_high:
     mov ax, VIEWPORT_MAX_Y
     mov player_y, ax
-    jmp @frame_loop
+    jmp NEAR PTR @frame_loop
 
 @exit_input:
     pop dx


### PR DESCRIPTION
## Summary
- avoid long relative jumps in HandleInput by routing through a short-range label
- force near jumps when returning to the frame loop to keep assembler within range

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df750ac990832c8eeb78b5c1442eeb