### PR TITLE
Fix ESC exit jump handling

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -566,7 +566,10 @@ HandleInput PROC
     int 16h
 
     cmp al, 27                     ; ESC -> salir del modo gráfico
-    je @exit_input
+    jne @not_escape
+    jmp NEAR PTR @exit_input
+
+@not_escape:
 
     mov bh, ah                     ; Guardar scan code
     mov bl, al                     ; Guardar ASCII


### PR DESCRIPTION
## Summary
- ensure the ESC key exit path uses a near jump to avoid relative jump overflows
- add a local label to keep conditional branches within range

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df75d651c8832c91350434c8803417