### PR TITLE
Fix keyboard polling loop

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -595,7 +595,10 @@ HandleInput PROC
 @frame_loop:
     mov ah, 01h                    ; Comprobar si hay tecla disponible (no bloqueante)
     int 16h
-    jz @frame_loop                 ; Continuar esperando sin redibujar
+    jnz @key_available             ; Continuar si hay una tecla lista
+    jmp @frame_loop                ; Reintentar hasta que se presione algo
+
+@key_available:
 
     mov ah, 00h                    ; Leer tecla (ASCII en AL, scan en AH)
     int 16h


### PR DESCRIPTION
## Summary
- split the keyboard polling logic to avoid a long backward short jump
- ensure the loop uses a near jump once no key is available

## Testing
- not run (assembly change only)


------
https://chatgpt.com/codex/tasks/task_e_68df86cb7318832c84c92370f5199ea5