### PR TITLE
Fix long conditional jumps in keyboard handler

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -791,12 +791,18 @@ MainLoop:
 
     mov ah, 01h
     int 16h
-    jz RenderFrame
+    jnz @KeyPressed
+    jmp RenderFrame
+
+@KeyPressed:
 
     mov ah, 00h
     int 16h
     cmp al, 1Bh
-    je ExitGraphics
+    jne @NotEscape
+    jmp ExitGraphics
+
+@NotEscape:
 
     mov bh, ah
     mov bl, al


### PR DESCRIPTION
## Summary
- restructure the keyboard handling path so conditional jumps no longer exceed the short-jump range

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e04310b60c832c9842b9e19d1b24c7