### PR TITLE
Replace blit rep movsb with manual loops

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -572,7 +572,12 @@ BlitBufferToScreen PROC
     mov bp, VIEWPORT_HEIGHT
 @RowCopy0:
     mov cx, BYTES_PER_SCAN
-    rep movsb
+@RowCopy0Bytes:
+    mov al, [ds:si]
+    mov [es:di], al
+    inc si
+    inc di
+    loop @RowCopy0Bytes
     add di, ROW_STRIDE_DIFF
     dec bp
     jnz @RowCopy0
@@ -599,7 +604,12 @@ BlitBufferToScreen PROC
     mov bp, VIEWPORT_HEIGHT
 @RowCopy1:
     mov cx, BYTES_PER_SCAN
-    rep movsb
+@RowCopy1Bytes:
+    mov al, [ds:si]
+    mov [es:di], al
+    inc si
+    inc di
+    loop @RowCopy1Bytes
     add di, ROW_STRIDE_DIFF
     dec bp
     jnz @RowCopy1
@@ -626,7 +636,12 @@ BlitBufferToScreen PROC
     mov bp, VIEWPORT_HEIGHT
 @RowCopy2:
     mov cx, BYTES_PER_SCAN
-    rep movsb
+@RowCopy2Bytes:
+    mov al, [ds:si]
+    mov [es:di], al
+    inc si
+    inc di
+    loop @RowCopy2Bytes
     add di, ROW_STRIDE_DIFF
     dec bp
     jnz @RowCopy2
@@ -653,7 +668,12 @@ BlitBufferToScreen PROC
     mov bp, VIEWPORT_HEIGHT
 @RowCopy3:
     mov cx, BYTES_PER_SCAN
-    rep movsb
+@RowCopy3Bytes:
+    mov al, [ds:si]
+    mov [es:di], al
+    inc si
+    inc di
+    loop @RowCopy3Bytes
     add di, ROW_STRIDE_DIFF
     dec bp
     jnz @RowCopy3


### PR DESCRIPTION
## Summary
- replace the REP MOVSB usage in BlitBufferToScreen with explicit byte copy loops for each plane to avoid potential DMA timing issues

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e048d332c0832cba23179a8f3a9a67