### PR TITLE
Fix DrawPixel bounds checks to avoid jump range errors

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -938,9 +938,15 @@ DrawPixel PROC
     push es
 
     cmp bx, VIEWPORT_WIDTH
-    jae @dp_exit_pixel
+    jb @dp_check_y_bounds
+    jmp @dp_exit_pixel
+
+@dp_check_y_bounds:
     cmp cx, VIEWPORT_HEIGHT
-    jae @dp_exit_pixel
+    jb @dp_continue_pixel
+    jmp @dp_exit_pixel
+
+@dp_continue_pixel:
 
     mov dh, dl
 


### PR DESCRIPTION
## Summary
- restructure the DrawPixel bounds checks so they branch locally before jumping to the shared exit path, avoiding short-jump range overflows

## Testing
- not run (DOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e35cd7729c832c91f14de2417930e1