### PR TITLE
Fix DrawPixel boundary jumps

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -960,9 +960,15 @@ DrawPixel PROC
 
     ; Verificar límites
     cmp bx, VIEWPORT_WIDTH
-    jae @dp_exit_pixel
+    jb @dp_check_y_bound
+    jmp @dp_exit_pixel
+
+@dp_check_y_bound:
     cmp cx, VIEWPORT_HEIGHT
-    jae @dp_exit_pixel
+    jb @dp_calculate_offset
+    jmp @dp_exit_pixel
+
+@dp_calculate_offset:
 
     ; Calcular offset y máscara
     mov ax, BYTES_PER_SCAN         ; 20


### PR DESCRIPTION
## Summary
- split DrawPixel boundary checks to use short conditional jumps
- avoid relative jump out-of-range errors when assembling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e37b630140832c8d1a6903809c0036