### PR TITLE
Handle far jumps in tile parser

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -619,12 +619,18 @@ ParseTwoInts PROC
     ; Verificar que hay contenido
     mov al, [si]
     cmp al, 0
-    je @pti_error_empty
+    jne @pti_not_empty
+    jmp @pti_error_empty
+
+@pti_not_empty:
 
 @pti_skip_ws1:
     mov al, [si]
     cmp al, 0
-    je @pti_error_empty
+    jne @pti_check_ws1
+    jmp @pti_error_empty
+
+@pti_check_ws1:
     cmp al, ' '
     je @pti_adv_ws1
     cmp al, 9


### PR DESCRIPTION
## Summary
- guard ParseTwoInts against long conditional branches by introducing intermediate labels
- route empty-line checks through near jumps that remain within range for TASM

## Testing
- not run (TASM/DOS environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e37e16b4a0832c87d051cc7054fc8f