### PR TITLE
Handle long conditional jump in BlitBufferToScreen

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -1672,7 +1672,10 @@ BlitBufferToScreen PROC
     ; Verificar que los buffers estén inicializados
     mov ax, Plane0Segment
     or ax, ax
-    jz @bbts_exit
+    jnz @bbts_has_buffers
+    jmp @bbts_exit
+
+@bbts_has_buffers:
 
     ; CRITICAL: Guardar offsets ANTES de cambiar DS
     mov bp, sp


### PR DESCRIPTION
## Summary
- add an intermediate label in `BlitBufferToScreen` to avoid a long conditional jump

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e385499998832ca73fab4696e6f386