### PR TITLE
Fix keyboard handler jumps

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -106,16 +106,28 @@ game_loop:
     
     ; Procesar teclas
     cmp ah, 48h     ; Arriba
-    je move_up
+    jne check_down
+    jmp move_up
+
+check_down:
     cmp ah, 50h     ; Abajo
-    je move_down
+    jne check_left
+    jmp move_down
+
+check_left:
     cmp ah, 4Bh     ; Izquierda
-    je move_left
+    jne check_right
+    jmp move_left
+
+check_right:
     cmp ah, 4Dh     ; Derecha
-    je move_right
+    jne check_escape
+    jmp move_right
+
+check_escape:
     cmp al, 27      ; ESC
-    je main_exit
-    jmp game_loop
+    jne game_loop
+    jmp main_exit
 
 move_up:
     cmp player_y, 1


### PR DESCRIPTION
## Summary
- update the keyboard handler to use near jumps for direction handling
- prevent short conditional jumps from exceeding their range by redirecting through intermediate labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5b2b63e34832c91552fe765f89b49