### PR TITLE
Handle out-of-range jumps in DrawSprite routine

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -1215,9 +1215,15 @@ DrawSprite PROC
     
     ; Verificar límites
     cmp cx, 640
-    jae ds_done
+    jb ds_check_y
+    jmp ds_done
+
+ds_check_y:
     cmp dx, 350
-    jae ds_done
+    jb ds_prepare
+    jmp ds_done
+
+ds_prepare:
     
     mov ax, VIDEO_SEG
     mov es, ax
@@ -1232,14 +1238,20 @@ DrawSprite PROC
     
 ds_row_simple:
     cmp bx, 0
-    je ds_done_simple
+    jne ds_row_continue
+    jmp ds_done_simple
+
+ds_row_continue:
     
     push cx             ; Guardar X inicial
     push ax             ; Guardar ancho
     
 ds_col_simple:
     cmp ax, 0
-    je ds_next_row_simple
+    jne ds_col_continue
+    jmp ds_next_row_simple
+
+ds_col_continue:
     
     ; Leer color del sprite
     push ax


### PR DESCRIPTION
## Summary
- restructure the DrawSprite boundary checks to use intermediate labels instead of direct conditional jumps
- refactor the sprite drawing loops to avoid short-jump range overflows reported by TASM

## Testing
- not run (assembly tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5d0aee6f8832ca2ae5f5ed7ddcb89