### PR TITLE
Fix ESC exit jump range

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -181,8 +181,11 @@ game_loop:
     
     ; ESC para salir
     cmp al, 27
-    je main_exit
+    je request_exit
     jmp game_loop
+
+request_exit:
+    jmp main_exit
 
 move_up:
     mov ax, player_y


### PR DESCRIPTION
## Summary
- add a local jump target for the ESC key handling so the assembler can encode the branch without range errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5df383cc8832cb5679dc0e882c04d