### PR TITLE
Fix long jump overflow in LoadMap error handling

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -656,9 +656,12 @@ LoadMap PROC
     mov al, 0
     mov ah, 3Dh
     int 21h
-    jc lm_use_default    ; ✅ Si no existe, usar por defecto
-    
+    jnc lm_open_ok       ; ✅ Si la apertura fue exitosa, continuar
+lm_open_failed:
+    jmp lm_use_default   ; ✅ Si no existe, usar por defecto
+
     ; ✅ VERIFICAR HANDLE VÁLIDO
+lm_open_ok:
     cmp ax, 0FFFFh       ; Handle inválido (-1)
     je lm_use_default
     cmp ax, 0            ; Handle 0 también es problemático


### PR DESCRIPTION
## Summary
- add an intermediate failure label to keep the conditional branch within range when opening the map file
- ensure the code still redirects to the default map on open failure

## Testing
- not run (16-bit DOS tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5e78871e0832c87e7b00c7019d48b