### PR TITLE
Fix move_right conditional jump range issue

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -191,8 +191,11 @@ check_arrows:
     cmp ah, 4Bh
     je move_left
     cmp ah, 4Dh
-    je move_right
-    
+    jne check_wasd
+    jmp move_right
+
+check_wasd:
+
     ; WASD
     cmp al, 'w'
     je move_up


### PR DESCRIPTION
## Summary
- reroute the move right branch through a nearby label to avoid the short jump range overflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5eca38c64832cbceab9b7766f36c0