### PR TITLE
Fix ES segment memory access syntax warnings

### DIFF
--- a/proyec.asm
+++ b/proyec.asm
@@ -514,8 +514,8 @@ dstb_pixel:
     mov dx, 03CEh
     out dx, ax
     
-    mov al, [es:di]
-    mov [es:di], ah
+    mov al, es:[di]
+    mov es:[di], ah
     pop di
     
     pop dx


### PR DESCRIPTION
## Summary
- correct the TASM syntax for memory access through the ES segment in `proyec.asm`

## Testing
- not run (DOS tooling unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5f39a9200832cb451d39362403d42